### PR TITLE
Release 0.1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ public void MarkupExtension()
 }
 ```
 
+You can unit test persistence of Application properties:
+```csharp
+[Test]
+public async Task SaveAndLoad()
+{
+    var app = new App();
+    app.Properties["Chuck"] = "Norris";
+    await app.SavePropertiesAsync();
+
+    app = new App();
+    Assert.AreEqual("Norris", app.Properties["Chuck"]);
+}
+```
+
 # How does it work?
 
 The main issue with trying to call `Xamarin.Forms.Init()` yourself for unit testing is that all kinds of interfaces and classes are marked `internal`. I get around this by conforming to `[assembly: InternalsVisibleTo]` which is declared for the purposes of unit testing Xamarin.Forms itself.
@@ -95,6 +109,5 @@ I tested everything with NUnit, but nothing is tied specifically to it. Things s
 
 - `Device.StartTimer` is not implemented. This is certainly possible.
 - I am not happy with `Device.BeginInvokeOnMainThread` being synchronous.
-- `GetUserStoreForApplication` is not implemented, this is probably used for things like `Properties` for persistence.
 - There are certainly other Xamarin.Forms internals not implemented. Let me know if there is something missing you need.
 - I back-dated this lib to support Xamarin.Forms 2.3.x, although it may be able to go back further. It is hard to know how often the forms team changed some of these internal interfaces.

--- a/Xamarin.Forms.Mocks.Tests/AnimationTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/AnimationTests.cs
@@ -1,5 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace Xamarin.Forms.Mocks.Tests
 {
@@ -17,6 +18,57 @@ namespace Xamarin.Forms.Mocks.Tests
         {
             var view = new BoxView();
             await view.FadeTo(0);
+            Assert.AreEqual(0, view.Opacity);
+        }
+
+        [Test]
+        public async Task ParallelFadeTo()
+        {
+            var a = new BoxView();
+            var b = new BoxView();
+            var list = new List<Task>
+            {
+                a.FadeTo(0),
+                b.FadeTo(0)
+            };
+            await Task.WhenAll(list);
+
+            Assert.AreEqual(0, a.Opacity);
+            Assert.AreEqual(0, b.Opacity);
+        }
+
+        [Test]
+        public async Task AnimationWithFinished()
+        {
+            var source = new TaskCompletionSource<bool>();
+
+            var view = new BoxView();
+            var animation = new Animation(v =>
+            {
+                view.Opacity = v;
+
+            }, 1, 0);
+            view.Animate("Fade", animation, finished: (a, b) => source.TrySetResult(true));
+
+            await source.Task;
+            Assert.AreEqual(0, view.Opacity);
+        }
+
+        [Test]
+        public async Task AnimationWithRepeatFinished()
+        {
+            var source = new TaskCompletionSource<bool>();
+
+            int count = 0;
+            var view = new BoxView();
+            var animation = new Animation(v =>
+            {
+                view.Opacity = v;
+
+            }, 1, 0);
+            view.Animate("Fade", animation, finished: (a, b) => source.TrySetResult(true), repeat: () => ++count == 3);
+
+            await source.Task;
             Assert.AreEqual(0, view.Opacity);
         }
     }

--- a/Xamarin.Forms.Mocks.Tests/AnimationTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/AnimationTests.cs
@@ -7,13 +7,15 @@ namespace Xamarin.Forms.Mocks.Tests
     [TestFixture]
     public class AnimationTests
     {
+        private const int Timeout = 1000;
+
         [SetUp]
         public void SetUp()
         {
             MockForms.Init();
         }
 
-        [Test]
+        [Test, Timeout(Timeout)]
         public async Task FadeTo()
         {
             var view = new BoxView();
@@ -21,7 +23,7 @@ namespace Xamarin.Forms.Mocks.Tests
             Assert.AreEqual(0, view.Opacity);
         }
 
-        [Test]
+        [Test, Timeout(Timeout)]
         public async Task ParallelFadeTo()
         {
             var a = new BoxView();
@@ -37,7 +39,7 @@ namespace Xamarin.Forms.Mocks.Tests
             Assert.AreEqual(0, b.Opacity);
         }
 
-        [Test]
+        [Test, Timeout(Timeout)]
         public async Task AnimationWithFinished()
         {
             var source = new TaskCompletionSource<bool>();
@@ -54,7 +56,7 @@ namespace Xamarin.Forms.Mocks.Tests
             Assert.AreEqual(0, view.Opacity);
         }
 
-        [Test]
+        [Test, Timeout(Timeout)]
         public async Task AnimationWithRepeatFinished()
         {
             var source = new TaskCompletionSource<bool>();

--- a/Xamarin.Forms.Mocks.Tests/PropertiesTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/PropertiesTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Mocks.Tests
+{
+    [TestFixture]
+    public class PropertiesTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            MockForms.Init();
+        }
+
+        class App : Application { }
+
+        [Test]
+        public async Task SaveDoesNotThrow()
+        {
+            await new App().SavePropertiesAsync();
+        }
+
+        [Test]
+        public async Task SaveAndLoad()
+        {
+            var app = new App();
+            app.Properties["Chuck"] = "Norris";
+            await app.SavePropertiesAsync();
+
+            app = new App();
+            Assert.AreEqual("Norris", app.Properties["Chuck"]);
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -51,6 +51,7 @@
     </Compile>
     <Compile Include="NavigationTests.cs" />
     <Compile Include="Views\TerribleExtension.cs" />
+    <Compile Include="PropertiesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -14,6 +15,7 @@ namespace Xamarin.Forms.Mocks
         {
             Device.PlatformServices = new PlatformServices();
             DependencyService.Register<SystemResourcesProvider>();
+            DependencyService.Register<Serializer>();
         }
 
         private class TestTicker : Ticker
@@ -116,6 +118,22 @@ namespace Xamarin.Forms.Mocks
             public IResourceDictionary GetSystemResources()
             {
                 return _dictionary;
+            }
+        }
+
+        private class Serializer : IDeserializer
+        {
+            private IDictionary<string, object> _properties = new Dictionary<string, object>();
+
+            public Task<IDictionary<string, object>> DeserializePropertiesAsync()
+            {
+                return Task.FromResult(_properties);
+            }
+
+            public Task SerializePropertiesAsync(IDictionary<string, object> properties)
+            {
+                _properties = properties;
+                return Task.FromResult(true);
             }
         }
     }

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -20,23 +20,22 @@ namespace Xamarin.Forms.Mocks
 
         private class TestTicker : Ticker
         {
-            private bool _inside = false;
+            private bool _enabled;
 
-            public override int Insert(Func<long, bool> timeout)
+            protected override void EnableTimer()
             {
-                var result = base.Insert(timeout);
-                if (!_inside)
+                _enabled = true;
+
+                while (_enabled)
                 {
-                    _inside = true;
-                    timeout(Environment.TickCount);
-                    _inside = false;
+                    SendSignals(16);
                 }
-                return result;
             }
 
-            protected override void DisableTimer() { }
-
-            protected override void EnableTimer() { }
+            protected override void DisableTimer()
+            {
+                _enabled = false;
+            }
         }
 
         private class PlatformServices : IPlatformServices

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var dirs = new[]
     Directory("./Xamarin.Forms.Mocks.Xaml/bin") + Directory(configuration),
 };
 string sln = "./Xamarin.Forms.Mocks.sln";
-string version = "0.1.0.3";
+string version = "0.1.0.4";
 
 Task("Clean")
     .Does(() =>


### PR DESCRIPTION
# Bug Fix

I was playing around with this on the Xamarin beta channel, and noticed `AnimationTests.cs` would never complete. I fixed the issue, and added a few more tests with animations.

# New Feature

You can now unit test Application properties:
```csharp
[Test]
public async Task SaveAndLoad()
{
    var app = new App();
    app.Properties["Chuck"] = "Norris";
    await app.SavePropertiesAsync();

    app = new App();
    Assert.AreEqual("Norris", app.Properties["Chuck"]);
}
```