### PR TITLE
Support for Xamarin.Forms 2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,19 @@ All animations will just complete immediately. Just `await` them and use `async`
 
 I tested everything with NUnit, but nothing is tied specifically to it. Things should work find if you want to use a different unit testing library.
 
-# Roadmap
+# Xamarin.Forms versions
+
+Make sure to choose the appropriate version of this package for the version of Xamarin.Forms you are using:
+| Xamarin.Forms  | Xamarin.Forms.Mocks |
+| ------------- | ------------- |
+| 2.3.4.x  | 2.3.4.1  |
+| 2.3.3.x  | 2.3.3.1  |
+| 2.3.0-2.3.2 | 0.1.0.4 |
+| Older | Unsupported |
+
+As another option, you can include the source code for this project along with your unit tests. This allows you to target any version of Xamarin.Forms desired assuming there are no code changes.
+
+# Wish List
 
 - `Device.StartTimer` is not implemented. This is certainly possible.
 - I am not happy with `Device.BeginInvokeOnMainThread` being synchronous.

--- a/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
@@ -5,21 +5,58 @@ namespace Xamarin.Forms.Mocks.Tests
     [TestFixture]
     public class DeviceTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-            MockForms.Init();
-        }
-
-        /// <summary>
-        /// NOTE: not currently sure if this is the best idea yet or not
-        /// </summary>
         [Test]
         public void BeginInvokeOnMainThreadIsSynchronous()
         {
+            MockForms.Init();
+
             bool success = false;
             Device.BeginInvokeOnMainThread(() => success = true);
             Assert.IsTrue(success);
+        }
+
+        [Test]
+        public void RuntimePlatformDefault()
+        {
+            MockForms.Init();
+
+            Assert.AreEqual("Test", Device.RuntimePlatform);
+        }
+
+        [Test]
+        public void RuntimePlatformiOS()
+        {
+            MockForms.Init(Device.iOS);
+
+            Assert.AreEqual(Device.iOS, Device.RuntimePlatform);
+            Assert.AreEqual(TargetPlatform.iOS, Device.OS);
+        }
+
+        [Test]
+        public void RuntimePlatformAndroid()
+        {
+            MockForms.Init(Device.Android);
+
+            Assert.AreEqual(Device.Android, Device.RuntimePlatform);
+            Assert.AreEqual(TargetPlatform.Android, Device.OS);
+        }
+
+        [Test]
+        public void RuntimePlatformWindows()
+        {
+            MockForms.Init(Device.Windows);
+
+            Assert.AreEqual(Device.Windows, Device.RuntimePlatform);
+            Assert.AreEqual(TargetPlatform.Windows, Device.OS);
+        }
+
+        [Test]
+        public void RuntimePlatformWinPhone()
+        {
+            MockForms.Init(Device.WinPhone);
+
+            Assert.AreEqual(Device.WinPhone, Device.RuntimePlatform);
+            Assert.AreEqual(TargetPlatform.WinPhone, Device.OS);
         }
     }
 }

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -30,13 +30,13 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -78,5 +78,5 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Xamarin.Forms.Mocks.Tests/packages.config
+++ b/Xamarin.Forms.Mocks.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="net45" />
+  <package id="Xamarin.Forms" version="2.3.4.224" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -33,18 +33,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Xamarin.Forms.Mocks.Xaml/packages.config
+++ b/Xamarin.Forms.Mocks.Xaml/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="2.3.4.224" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/Xamarin.Forms.Mocks.nuspec
+++ b/Xamarin.Forms.Mocks.nuspec
@@ -15,7 +15,7 @@
       <releaseNotes>Initial Release</releaseNotes>
       <tags>Xamarin, Xamarin.Forms, Mocks, Unit Testing</tags>
       <dependencies>
-         <dependency id="Xamarin.Forms" version="2.3.3.193" />
+         <dependency id="Xamarin.Forms" version="2.3.4.224" />
       </dependencies>
    </metadata>
 </package>

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -45,6 +45,11 @@ namespace Xamarin.Forms.Mocks
                 get { return false; }
             }
 
+            public string RuntimePlatform
+            {
+                get { return "Test"; }
+            }
+
             public void BeginInvokeOnMainThread(Action action)
             {
                 action();
@@ -53,31 +58,6 @@ namespace Xamarin.Forms.Mocks
             public Ticker CreateTicker()
             {
                 return new TestTicker();
-            }
-
-            public ITimer CreateTimer(Action<object> callback)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITimer CreateTimer(Action<object> callback, object state, uint dueTime, uint period)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITimer CreateTimer(Action<object> callback, object state, TimeSpan dueTime, TimeSpan period)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITimer CreateTimer(Action<object> callback, object state, long dueTime, long period)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITimer CreateTimer(Action<object> callback, object state, int dueTime, int period)
-            {
-                throw new NotImplementedException();
             }
 
             public Assembly[] GetAssemblies()

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -11,9 +11,9 @@ namespace Xamarin.Forms.Mocks
 {
     public static class MockForms
     {
-        public static void Init()
+        public static void Init(string runtimePlatform = "Test")
         {
-            Device.PlatformServices = new PlatformServices();
+            Device.PlatformServices = new PlatformServices(runtimePlatform);
             DependencyService.Register<SystemResourcesProvider>();
             DependencyService.Register<Serializer>();
         }
@@ -40,6 +40,11 @@ namespace Xamarin.Forms.Mocks
 
         private class PlatformServices : IPlatformServices
         {
+            public PlatformServices(string runtimePlatform)
+            {
+                RuntimePlatform = runtimePlatform;
+            }
+
             public bool IsInvokeRequired
             {
                 get { return false; }
@@ -47,7 +52,8 @@ namespace Xamarin.Forms.Mocks
 
             public string RuntimePlatform
             {
-                get { return "Test"; }
+                get;
+                private set;
             }
 
             public void BeginInvokeOnMainThread(Action action)

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -33,18 +33,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.224\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.224\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Xamarin.Forms.Mocks/packages.config
+++ b/Xamarin.Forms.Mocks/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="2.3.4.224" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var dirs = new[]
     Directory("./Xamarin.Forms.Mocks.Xaml/bin") + Directory(configuration),
 };
 string sln = "./Xamarin.Forms.Mocks.sln";
-string version = "2.3.3.1";
+string version = "2.3.4.1";
 
 Task("Clean")
     .Does(() =>


### PR DESCRIPTION
- Supports changes to `IPlatformServices` in 2.3.4.
- Added a new feature for mocking RuntimePlatform, see unit tests in b60cf3bc47361f8191f8822cb0231c1cc634453f

Fixes #2 