### PR TITLE
Add helper to access Uri sent to Device.OpenUri

### DIFF
--- a/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace Xamarin.Forms.Mocks.Tests
 {
@@ -57,6 +58,27 @@ namespace Xamarin.Forms.Mocks.Tests
 
             Assert.AreEqual(Device.WinPhone, Device.RuntimePlatform);
             Assert.AreEqual(TargetPlatform.WinPhone, Device.OS);
+        }
+
+        [Test]
+        public void OpenUriActionCall()
+        {
+            Uri actual = null;
+            int callCount = 0;
+
+            MockForms.OpenUriAction = u =>
+            {
+                actual = u;
+                callCount++;
+            };
+            MockForms.Init();
+            
+            var expectedUri = new Uri("https://www.google.com");
+
+            Device.OpenUri(expectedUri);
+
+            Assert.AreEqual(expectedUri, actual);
+            Assert.AreEqual(1, callCount);
         }
     }
 }

--- a/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
@@ -61,8 +61,10 @@ namespace Xamarin.Forms.Mocks.Tests
         }
 
         [Test]
-        public void OpenUriActionCall()
+        public void OpenUri()
         {
+            MockForms.Init();
+
             Uri actual = null;
             int callCount = 0;
 
@@ -71,14 +73,29 @@ namespace Xamarin.Forms.Mocks.Tests
                 actual = u;
                 callCount++;
             };
-            MockForms.Init();
-            
+
             var expectedUri = new Uri("https://www.google.com");
 
             Device.OpenUri(expectedUri);
 
             Assert.AreEqual(expectedUri, actual);
             Assert.AreEqual(1, callCount);
+        }
+
+        [Test]
+        public void InitClearsOpenUri()
+        {
+            MockForms.OpenUriAction = delegate { };
+            MockForms.Init();
+            Assert.IsNull(MockForms.OpenUriAction);
+        }
+
+        [Test]
+        public void OpenUriDoesNotThrowOnNull()
+        {
+            MockForms.Init();
+            MockForms.OpenUriAction = null;
+            Device.OpenUri(new Uri("https://www.google.com"));
         }
     }
 }

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -11,7 +11,11 @@ namespace Xamarin.Forms.Mocks
 {
     public static class MockForms
     {
-        public static Action<Uri> OpenUriAction { get; set; } = delegate { };
+        /// <summary>
+        /// Callback for asserting against Device.OpenUri
+        /// NOTE: MockForms.Init() clears this value
+        /// </summary>
+        public static Action<Uri> OpenUriAction { get; set; }
 
         public static void Init(string runtimePlatform = "Test")
         {
@@ -19,6 +23,7 @@ namespace Xamarin.Forms.Mocks
             DependencyService.Register<SystemResourcesProvider>();
             DependencyService.Register<Serializer>();
             DependencyService.Register<ValueConverterProvider>();
+            OpenUriAction = null;
         }
 
         private class TestTicker : Ticker
@@ -96,7 +101,7 @@ namespace Xamarin.Forms.Mocks
 
             public void OpenUriAction(Uri uri)
             {
-                MockForms.OpenUriAction(uri);
+                MockForms.OpenUriAction?.Invoke(uri);
             }
 
             public void StartTimer(TimeSpan interval, Func<bool> callback) { }

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms.Mocks
 {
     public static class MockForms
     {
+        public static Action<Uri> OpenUriAction { get; set; } = delegate { };
+
         public static void Init(string runtimePlatform = "Test")
         {
             Device.PlatformServices = new PlatformServices(runtimePlatform);
@@ -92,7 +94,10 @@ namespace Xamarin.Forms.Mocks
                 throw new NotImplementedException();
             }
 
-            public void OpenUriAction(Uri uri) { }
+            public void OpenUriAction(Uri uri)
+            {
+                MockForms.OpenUriAction(uri);
+            }
 
             public void StartTimer(TimeSpan interval, Func<bool> callback) { }
         }


### PR DESCRIPTION
Added the helper class to allow checking the Uri sent to the Device.OpenUri method call. Also tracks the amount of time the method is called