### PR TITLE
Implemented Device.StartTimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ public void OpenUri()
 }
 ```
 
+You can use `Device.StartTimer` as you would expect:
+```csharp
+[Test]
+public async Task StartTimer()
+{
+    var source = new TaskCompletionSource<bool>();
+    Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
+    {
+        source.SetResult(true);
+        return false;
+    });
+
+    Assert.IsTrue(await source.Task);
+}
+```
+
 To test things using `Application.Current` or its resources:
 ```csharp
 [SetUp]
@@ -159,7 +175,6 @@ As another option, you can include the source code for this project along with y
 
 # Wish List
 
-- `Device.StartTimer` is not implemented. This is certainly possible.
 - I am not happy with `Device.BeginInvokeOnMainThread` being synchronous.
 - There are certainly other Xamarin.Forms internals not implemented. Let me know if there is something missing you need.
 - I back-dated this lib to support Xamarin.Forms 2.3.x, although it may be able to go back further. It is hard to know how often the forms team changed some of these internal interfaces.

--- a/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Xamarin.Forms.Mocks.Tests
@@ -135,6 +136,43 @@ namespace Xamarin.Forms.Mocks.Tests
             MockForms.Init();
 
             Assert.AreEqual(TargetIdiom.Unsupported, Device.Idiom);
+        }
+
+        [Test]
+        public async Task StartTimer()
+        {
+            MockForms.Init();
+
+            var source = new TaskCompletionSource<bool>();
+            Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
+            {
+                source.SetResult(true);
+                return false;
+            });
+
+            Assert.IsTrue(await source.Task);
+        }
+
+        [Test]
+        public async Task StartTimerRepeating()
+        {
+            MockForms.Init();
+
+            const int max = 10;
+            int count = 0;
+            var source = new TaskCompletionSource<int>();
+            Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
+            {
+                if (++count == max)
+                {
+                    source.SetResult(count);
+                    return false;
+                }
+
+                return true;
+            });
+
+            Assert.AreEqual(max, await source.Task);
         }
     }
 }

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -107,7 +107,16 @@ namespace Xamarin.Forms.Mocks
 
             public void QuitApplication() { }
 
-            public void StartTimer(TimeSpan interval, Func<bool> callback) { }
+            public async void StartTimer(TimeSpan interval, Func<bool> callback)
+            {
+                while (true)
+                {
+                    await Task.Delay(interval);
+
+                    if (!callback())
+                        return;
+                }
+            }
         }
 
         private class SystemResourcesProvider : ISystemResourcesProvider


### PR DESCRIPTION
This feature has been missing for a while, and it was requested on Twitter. It actually is pretty easy to implement using async/await. I added two unit tests that show that is works in general.

It remains to be seen if it will be easy to write tests against views using `Device.StartTimer`. Unless you you model your view's APIs to use `Task` and `TaskCompletionSource<T>` these views will not be very testable. If you are dealing with existing code, adding a `Task.Delay` in your tests (longer than the timer) will *work*, but it is not ideal.