### PR TITLE
Mock IIsolatedStorageFile implementation

### DIFF
--- a/Xamarin.Forms.Mocks.Tests/IsolatedStorageFileTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/IsolatedStorageFileTests.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Mocks.Tests
+{
+    [TestFixture]
+    public class IsolatedStorageFileTests
+    {
+        private IsolatedStorageFile _file;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _file = new IsolatedStorageFile();
+        }
+
+        [Test]
+        public async Task CreateDirectory()
+        {
+            string path = "/test/";
+            await _file.CreateDirectoryAsync(path);
+            Assert.IsTrue(await _file.GetDirectoryExistsAsync(path));
+            Assert.IsFalse(await _file.GetFileExistsAsync(path));
+        }
+
+        [Test]
+        public async Task OpenFile()
+        {
+            string path = "test.txt";
+            Assert.IsNotNull(await _file.OpenFileAsync(path, 0, 0));
+            Assert.IsTrue(await _file.GetFileExistsAsync(path));
+            Assert.IsFalse(await _file.GetDirectoryExistsAsync(path));
+        }
+
+        [Test]
+        public async Task LastWriteTime()
+        {
+            string path = "test.txt";
+            await _file.OpenFileAsync(path, 0, 0);
+
+            var lastWriteTime = await _file.GetLastWriteTimeAsync(path);
+            await Task.Delay(10);
+            await _file.OpenFileAsync(path, 0, 0);
+
+            Assert.AreNotEqual(lastWriteTime, await _file.GetLastWriteTimeAsync(path));
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks.Tests/LoadFromXamlTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/LoadFromXamlTests.cs
@@ -68,5 +68,13 @@ namespace Xamarin.Forms.Mocks.Tests
             Assert.IsNotNull(layout);
             Assert.AreEqual(new Thickness(20), layout.Margin);
         }
+
+        [Test]
+        public void UriImageSource()
+        {
+            var image = new Image();
+            image.LoadFromXaml("<Image xmlns=\"http://xamarin.com/schemas/2014/forms\"><Image.Source><UriImageSource Uri=\"https://upload.wikimedia.org/wikipedia/commons/3/30/Chuck_Norris_May_2015.jpg\" CachingEnabled=\"True\" CacheValidity=\"5\"/></Image.Source></Image>");
+            Assert.IsInstanceOf<UriImageSource>(image.Source);
+        }
     }
 }

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationTests.cs" />
+    <Compile Include="IsolatedStorageFileTests.cs" />
     <Compile Include="LoadFromXamlTests.cs" />
     <Compile Include="AnimationTests.cs" />
     <Compile Include="DeviceTests.cs" />

--- a/Xamarin.Forms.Mocks/IsolatedStorageFile.cs
+++ b/Xamarin.Forms.Mocks/IsolatedStorageFile.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    internal class IsolatedStorageFile : IIsolatedStorageFile
+    {
+        private Dictionary<string, MockFileSystemObject> _files = new Dictionary<string, MockFileSystemObject>();
+
+        private MockFileSystemObject GetFileSystemObject(string path, bool throwOnNotFound = false)
+        {
+            MockFileSystemObject file;
+            if (!_files.TryGetValue(path, out file))
+            {
+                if (throwOnNotFound)
+                    throw new FileNotFoundException("Not found!", path);
+
+                _files[path] = file = new MockFileSystemObject(false);
+            }
+            return file;
+        }
+
+        public Task CreateDirectoryAsync(string path)
+        {
+            _files[path] = new MockFileSystemObject(true);
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> GetDirectoryExistsAsync(string path)
+        {
+            var file = GetFileSystemObject(path);
+            return Task.FromResult(file.IsDirectory);
+        }
+
+        public Task<bool> GetFileExistsAsync(string path)
+        {
+            var file = GetFileSystemObject(path);
+            return Task.FromResult(!file.IsDirectory);
+        }
+
+        public Task<DateTimeOffset> GetLastWriteTimeAsync(string path)
+        {
+            var file = GetFileSystemObject(path);
+            return Task.FromResult(file.LastWriteTime);
+        }
+
+        public Task<Stream> OpenFileAsync(string path, Internals.FileMode mode, Internals.FileAccess access)
+        {
+            var file = GetFileSystemObject(path);
+            file.SetModified();
+            return Task.FromResult(file.Stream);
+        }
+
+        public Task<Stream> OpenFileAsync(string path, Internals.FileMode mode, Internals.FileAccess access, Internals.FileShare share)
+        {
+            var file = GetFileSystemObject(path);
+            file.SetModified();
+            return Task.FromResult(file.Stream);
+        }
+
+        class MockFileSystemObject
+        {
+            public MockFileSystemObject(bool isDirectory)
+            {
+                if (!(IsDirectory = isDirectory))
+                {
+                    Stream = new MemoryStream();
+                }
+                SetModified();
+            }
+
+            public bool IsDirectory { get; private set; }
+
+            public Stream Stream { get; private set; }
+
+            public DateTimeOffset LastWriteTime { get; private set; }
+
+            public void SetModified()
+            {
+                LastWriteTime = DateTimeOffset.Now;
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using Xamarin.Forms.Internals;
+using System.Runtime.CompilerServices;
 using Xamarin.Forms.Mocks.Xaml;
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.Mocks.Tests")]
 
 namespace Xamarin.Forms.Mocks
 {
@@ -25,124 +22,6 @@ namespace Xamarin.Forms.Mocks
             DependencyService.Register<Serializer>();
             DependencyService.Register<ValueConverterProvider>();
             OpenUriAction = null;
-        }
-
-        private class TestTicker : Ticker
-        {
-            private bool _enabled;
-
-            protected override void EnableTimer()
-            {
-                _enabled = true;
-
-                while (_enabled)
-                {
-                    SendSignals(16);
-                }
-            }
-
-            protected override void DisableTimer()
-            {
-                _enabled = false;
-            }
-        }
-
-        private class PlatformServices : IPlatformServices
-        {
-            public PlatformServices(string runtimePlatform)
-            {
-                RuntimePlatform = runtimePlatform;
-            }
-
-            public bool IsInvokeRequired
-            {
-                get { return false; }
-            }
-
-            public string RuntimePlatform
-            {
-                get;
-                private set;
-            }
-
-            public void BeginInvokeOnMainThread(Action action)
-            {
-                action();
-            }
-
-            public Ticker CreateTicker()
-            {
-                return new TestTicker();
-            }
-
-            public Assembly[] GetAssemblies()
-            {
-                return new Assembly[0];
-            }
-
-            public string GetMD5Hash(string input)
-            {
-                throw new NotImplementedException();
-            }
-
-            public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
-            {
-                return 14;
-            }
-
-            public Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
-            public IIsolatedStorageFile GetUserStoreForApplication()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void OpenUriAction(Uri uri)
-            {
-                MockForms.OpenUriAction?.Invoke(uri);
-            }
-
-            public void QuitApplication() { }
-
-            public async void StartTimer(TimeSpan interval, Func<bool> callback)
-            {
-                while (true)
-                {
-                    await Task.Delay(interval);
-
-                    if (!callback())
-                        return;
-                }
-            }
-        }
-
-        private class SystemResourcesProvider : ISystemResourcesProvider
-        {
-            private ResourceDictionary _dictionary = new ResourceDictionary();
-
-            public IResourceDictionary GetSystemResources()
-            {
-                return _dictionary;
-            }
-        }
-
-        private class Serializer : IDeserializer
-        {
-            private IDictionary<string, object> _properties = new Dictionary<string, object>();
-
-            public Task<IDictionary<string, object>> DeserializePropertiesAsync()
-            {
-                return Task.FromResult(_properties);
-            }
-
-            public Task SerializePropertiesAsync(IDictionary<string, object> properties)
-            {
-                _properties = properties;
-                return Task.FromResult(true);
-            }
         }
     }
 }

--- a/Xamarin.Forms.Mocks/PlatformServices.cs
+++ b/Xamarin.Forms.Mocks/PlatformServices.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    internal class PlatformServices : IPlatformServices
+    {
+        private readonly IsolatedStorageFile _isolatedStorageFile = new IsolatedStorageFile();
+
+        public PlatformServices(string runtimePlatform)
+        {
+            RuntimePlatform = runtimePlatform;
+        }
+
+        public bool IsInvokeRequired
+        {
+            get { return false; }
+        }
+
+        public string RuntimePlatform
+        {
+            get;
+            private set;
+        }
+
+        public void BeginInvokeOnMainThread(Action action)
+        {
+            action();
+        }
+
+        public Ticker CreateTicker()
+        {
+            return new TestTicker();
+        }
+
+        public Assembly[] GetAssemblies()
+        {
+            return new Assembly[0];
+        }
+
+        public string GetMD5Hash(string input)
+        {
+            throw new NotImplementedException();
+        }
+
+        public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
+        {
+            return 14;
+        }
+
+        public Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IIsolatedStorageFile GetUserStoreForApplication()
+        {
+            return _isolatedStorageFile;
+        }
+
+        public void OpenUriAction(Uri uri)
+        {
+            MockForms.OpenUriAction?.Invoke(uri);
+        }
+
+        public void QuitApplication() { }
+
+        public async void StartTimer(TimeSpan interval, Func<bool> callback)
+        {
+            while (true)
+            {
+                await Task.Delay(interval);
+
+                if (!callback())
+                    return;
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks/Serializer.cs
+++ b/Xamarin.Forms.Mocks/Serializer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    internal class Serializer : IDeserializer
+    {
+        private IDictionary<string, object> _properties = new Dictionary<string, object>();
+
+        public Task<IDictionary<string, object>> DeserializePropertiesAsync()
+        {
+            return Task.FromResult(_properties);
+        }
+
+        public Task SerializePropertiesAsync(IDictionary<string, object> properties)
+        {
+            _properties = properties;
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks/SystemResourcesProvider.cs
+++ b/Xamarin.Forms.Mocks/SystemResourcesProvider.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    internal class SystemResourcesProvider : ISystemResourcesProvider
+    {
+        private ResourceDictionary _dictionary = new ResourceDictionary();
+
+        public IResourceDictionary GetSystemResources()
+        {
+            return _dictionary;
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks/TestTicker.cs
+++ b/Xamarin.Forms.Mocks/TestTicker.cs
@@ -1,0 +1,24 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    internal class TestTicker : Ticker
+    {
+        private bool _enabled;
+
+        protected override void EnableTimer()
+        {
+            _enabled = true;
+
+            while (_enabled)
+            {
+                SendSignals(16);
+            }
+        }
+
+        protected override void DisableTimer()
+        {
+            _enabled = false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #24 

- Xaml test repro's #24 
- Split up `MockForms.cs`
  - Moved all the nested classes to their own files, marked them `internal`
  - Setup `InternalsVisibleTo` for unit tests
  - Implemented a quick mock/fake `IsolatedStorageFile` implementation
- reasonable smoke tests for `IsolatedStorageFile`