### PR TITLE
Updated for 4.0.0.8055-pre1

### DIFF
--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
+    <PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -4,6 +4,6 @@
 		<AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
+		<PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
 	</ItemGroup>
 </Project>

--- a/Xamarin.Forms.Mocks/PlatformServices.cs
+++ b/Xamarin.Forms.Mocks/PlatformServices.cs
@@ -69,6 +69,11 @@ namespace Xamarin.Forms.Mocks
 
         public void QuitApplication() { }
 
+        public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+        {
+            return new SizeRequest();
+        }
+
         public async void StartTimer(TimeSpan interval, Func<bool> callback)
         {
             while (true)

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Xamarin.Forms.Core.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
+		<PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />


### PR DESCRIPTION
Fixes #31 

The current XF pre-release gets the [PlatformServices.GetNativeSize()](https://github.com/xamarin/Xamarin.Forms/blob/505a855cad39322c8b235281d71c35b70c9df129/Xamarin.Forms.Core/IPlatformServices.cs#L38) method not found.