### PR TITLE
Support for Xamarin.Forms 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Make sure to choose the appropriate version of this package for the version of X
 
 | Xamarin.Forms  | Xamarin.Forms.Mocks |
 | -------------- | ------------------- |
-| 4.0.0.x        | 4.0.0.x             |
+| 3.5.0.x        | 3.5.0.x             |
 | 3.0.0.x        | 3.0.0.x             |
 | 2.5.0.x        | 2.5.0.x             |
 | 2.4.0.x        | 2.4.0.x             |

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
+    <PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
     <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -4,6 +4,6 @@
 		<AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
+		<PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
 	</ItemGroup>
 </Project>

--- a/Xamarin.Forms.Mocks.nuspec
+++ b/Xamarin.Forms.Mocks.nuspec
@@ -15,7 +15,7 @@
       <releaseNotes>Upgraded to netstandard2.0</releaseNotes>
       <tags>Xamarin, Xamarin.Forms, Mocks, Unit Testing</tags>
       <dependencies>
-         <dependency id="Xamarin.Forms" version="4.0.0.8055-pre1" />
+         <dependency id="Xamarin.Forms" version="3.5.0.129452" />
       </dependencies>
    </metadata>
 </package>

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Xamarin.Forms.Core.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.0.0.8055-pre1" />
+		<PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />

--- a/build.cake
+++ b/build.cake
@@ -16,8 +16,8 @@ var dirs = new[]
     Directory("./Xamarin.Forms.Mocks.Xaml/obj") + Directory(configuration),
 };
 string sln = "./Xamarin.Forms.Mocks.sln";
-string version = "4.0.0.0";
-string suffix = "-pre1";
+string version = "3.5.0.0";
+string suffix = "";
 
 Task("Clean")
     .Does(() =>
@@ -80,6 +80,6 @@ Task("NuGet-Push")
     });
 
 Task("Default")
-    .IsDependentOn("NuGet-Push");
+    .IsDependentOn("NuGet-Package");
 
 RunTarget(target);


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/issues/34

Originally targeted a XF 4.0 preview, but we need to target 3.5 instead.

*also tweaked build.cake*