### PR TITLE
Support for MarkupExtension in other assemblies

### DIFF
--- a/TestAssembly/FooExtension.cs
+++ b/TestAssembly/FooExtension.cs
@@ -3,16 +3,16 @@ using Xamarin.Forms.Xaml;
 
 namespace TestAssembly
 {
-	public class FooExtension : IMarkupExtension<string>
-	{
-		public string ProvideValue (IServiceProvider serviceProvider)
-		{
-			return "Bar";
-		}
+    public class FooExtension : IMarkupExtension<string>
+    {
+        public string ProvideValue (IServiceProvider serviceProvider)
+        {
+            return "Bar";
+        }
 
-		object IMarkupExtension.ProvideValue (IServiceProvider serviceProvider)
-		{
-			return ProvideValue (serviceProvider);
-		}
-	}
+        object IMarkupExtension.ProvideValue (IServiceProvider serviceProvider)
+        {
+            return ProvideValue (serviceProvider);
+        }
+    }
 }

--- a/TestAssembly/FooExtension.cs
+++ b/TestAssembly/FooExtension.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Xamarin.Forms.Xaml;
+
+namespace TestAssembly
+{
+	public class FooExtension : IMarkupExtension<string>
+	{
+		public string ProvideValue (IServiceProvider serviceProvider)
+		{
+			return "Bar";
+		}
+
+		object IMarkupExtension.ProvideValue (IServiceProvider serviceProvider)
+		{
+			return ProvideValue (serviceProvider);
+		}
+	}
+}

--- a/TestAssembly/TestAssembly.csproj
+++ b/TestAssembly/TestAssembly.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.220655" />
+  </ItemGroup>
+
+</Project>

--- a/Xamarin.Forms.Mocks.Tests/LoadFromXamlTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/LoadFromXamlTests.cs
@@ -29,6 +29,14 @@ namespace Xamarin.Forms.Mocks.Tests
         }
 
         [Test]
+        public void MarkupExtensionInOtherAssembly ()
+        {
+            var label = new Label ();
+            label.LoadFromXaml ("<Label xmlns:f=\"clr-namespace:TestAssembly;assembly=TestAssembly\" Text=\"{f:Foo}\" />");
+            Assert.AreEqual ("Bar", label.Text);
+        }
+
+        [Test]
         public void LoadViaNew()
         {
             var view = new TestView();

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Mocks\Xamarin.Forms.Mocks.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />
   </ItemGroup>

--- a/Xamarin.Forms.Mocks.sln
+++ b/Xamarin.Forms.Mocks.sln
@@ -1,11 +1,16 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Mocks", "Xamarin.Forms.Mocks\Xamarin.Forms.Mocks.csproj", "{AFB557D0-683D-4370-8851-23A617B8079A}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28922.388
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Mocks", "Xamarin.Forms.Mocks\Xamarin.Forms.Mocks.csproj", "{AFB557D0-683D-4370-8851-23A617B8079A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Mocks.Xaml", "Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj", "{3D6DA511-5995-48B7-89DD-CD8D08993907}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Mocks.Xaml", "Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj", "{3D6DA511-5995-48B7-89DD-CD8D08993907}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Mocks.Tests", "Xamarin.Forms.Mocks.Tests\Xamarin.Forms.Mocks.Tests.csproj", "{2ECEE799-2725-4E43-8835-119F1D0FF1A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Mocks.Tests", "Xamarin.Forms.Mocks.Tests\Xamarin.Forms.Mocks.Tests.csproj", "{2ECEE799-2725-4E43-8835-119F1D0FF1A5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{633E81F0-48E3-406F-90AE-A1B4ADF46DD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestAssembly", "TestAssembly\TestAssembly.csproj", "{9643543F-E3B3-4723-925A-E33D7E6108A4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,5 +30,19 @@ Global
 		{2ECEE799-2725-4E43-8835-119F1D0FF1A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2ECEE799-2725-4E43-8835-119F1D0FF1A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ECEE799-2725-4E43-8835-119F1D0FF1A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9643543F-E3B3-4723-925A-E33D7E6108A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9643543F-E3B3-4723-925A-E33D7E6108A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9643543F-E3B3-4723-925A-E33D7E6108A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9643543F-E3B3-4723-925A-E33D7E6108A4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2ECEE799-2725-4E43-8835-119F1D0FF1A5} = {633E81F0-48E3-406F-90AE-A1B4ADF46DD1}
+		{9643543F-E3B3-4723-925A-E33D7E6108A4} = {633E81F0-48E3-406F-90AE-A1B4ADF46DD1}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B8047231-E155-493D-9257-FC21BDE46D90}
 	EndGlobalSection
 EndGlobal

--- a/Xamarin.Forms.Mocks/PlatformServices.cs
+++ b/Xamarin.Forms.Mocks/PlatformServices.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Mocks
 
         public Assembly[] GetAssemblies()
         {
-            return new Assembly[0];
+            return AppDomain.CurrentDomain.GetAssemblies ();
         }
 
         public string GetMD5Hash(string input)


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/issues/40

We need to return `AppDomain.CurrentDomain.GetAssemblies()` instead of an empty array!