### PR TITLE
[build] locate MSBuild properly

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -19,6 +19,37 @@ string sln = "./Xamarin.Forms.Mocks.sln";
 string version = "3.5.0.2";
 string suffix = "";
 
+MSBuildSettings MSBuildSettings()
+{
+    var settings = new MSBuildSettings { Configuration = configuration };
+
+    if (IsRunningOnWindows())
+    {
+        // Find MSBuild for Visual Studio 2019 and newer
+        DirectoryPath vsLatest = VSWhereLatest();
+        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
+
+        // Find MSBuild for Visual Studio 2017
+        if (msBuildPath != null && !FileExists(msBuildPath))
+            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+
+        // Have we found MSBuild yet?
+        if (!FileExists(msBuildPath))
+        {
+            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
+        }
+
+        Information("Building using MSBuild at " + msBuildPath);
+        settings.ToolPath = msBuildPath;
+    }
+    else
+    {
+        settings.ToolPath = Context.Tools.Resolve("msbuild");
+    }
+
+    return settings.WithRestore();
+}
+
 Task("Clean")
     .Does(() =>
     {
@@ -30,7 +61,7 @@ Task("Build")
     .IsDependentOn("Clean")
     .Does(() =>
     {
-        MSBuild(sln, settings => settings.SetConfiguration(configuration).WithRestore());
+        MSBuild(sln, MSBuildSettings());
     });
 
 Task("NUnit")


### PR DESCRIPTION
Context: https://github.com/nunit/nunit/pull/3194

I tried to build this repo on a new machine that only has VS 2019 installed. It didn't build...

I pulled a fix over that NUnit is using in their Cake script.