### PR TITLE
Set Device.Info to fix master/detail template

### DIFF
--- a/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/DeviceTests.cs
@@ -196,5 +196,13 @@ namespace Xamarin.Forms.Mocks.Tests
 
             Assert.AreEqual(max, await source.Task);
         }
+
+        [Test]
+        public void DeviceInfo ()
+        {
+            //Device.Info is EditorBrowsable.Never, but is used internally by Master/Detail template
+            MockForms.Init();
+            Device.Info.ToString();
+        }
     }
 }

--- a/Xamarin.Forms.Mocks/MockDeviceInfo.cs
+++ b/Xamarin.Forms.Mocks/MockDeviceInfo.cs
@@ -1,0 +1,29 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Mocks
+{
+    public class MockDeviceInfo : DeviceInfo
+    {
+        public override Size PixelScreenSize
+        {
+            get
+            {
+                if (CurrentOrientation == DeviceOrientation.Landscape)
+                    return new Size(1080, 1920);
+                else
+                    return new Size(1920, 1080);
+            }
+        }
+
+        public override Size ScaledScreenSize
+        {
+            get
+            {
+                var pixelSize = PixelScreenSize;
+                return new Size(pixelSize.Width / ScalingFactor, pixelSize.Height / ScalingFactor);
+            }
+        }
+
+        public override double ScalingFactor => 2;
+    }
+}

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Mocks
         {
             Device.PlatformServices = new PlatformServices(runtimePlatform);
             Device.Idiom = idiom;
+            Device.Info = new MockDeviceInfo();
             DependencyService.Register<SystemResourcesProvider>();
             DependencyService.Register<Serializer>();
             DependencyService.Register<ValueConverterProvider>();


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/issues/49
Context: https://github.com/xamarin/Xamarin.Forms/blob/53b978958adaed4305de02e9971091ce63e909b1/Xamarin.Forms.DualScreen.UnitTests/TestDeviceInfo.cs

The Forms Master/Detail template was hitting:

    System.InvalidOperationException : You MUST call Xamarin.Forms.Init(); prior to using it.

I could reproduce the same problem with two lines of code:

    MockForms.Init();
    Xamarin.Forms.Device.Info.ToString();

It appears this library never implemented `Device.Info`, which is used internally by Xamarin.Forms.