### PR TITLE
update to Xamarin.Forms 4.6

### DIFF
--- a/Xamarin.Forms.Mocks.Tests/AppThemeTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/AppThemeTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Mocks.Tests
+{
+    [TestFixture]
+    public class AppThemeTests
+    {
+        [Test]
+        public void DefaultAppThemeIsUnspecified()
+        {
+            MockForms.Init();
+            var str = new OnAppTheme<string>
+            {
+                Default = "Unspecified",
+                Dark = "Dark",
+                Light = "Light"
+            };
+            Assert.AreEqual("Unspecified", str.Value);
+        }
+
+        [Test]
+        public void RequestedThemeIsSet()
+        {
+            MockForms.Init(requestedTheme: OSAppTheme.Dark);
+            var str = new OnAppTheme<string>
+            {
+                Default = "Unspecified",
+                Dark = "Dark",
+                Light = "Light"
+            };
+            Assert.AreEqual("Dark", str.Value);
+        }
+    }
+}

--- a/Xamarin.Forms.Mocks.Tests/AppThemeTests.cs
+++ b/Xamarin.Forms.Mocks.Tests/AppThemeTests.cs
@@ -12,26 +12,17 @@ namespace Xamarin.Forms.Mocks.Tests
         public void DefaultAppThemeIsUnspecified()
         {
             MockForms.Init();
-            var str = new OnAppTheme<string>
-            {
-                Default = "Unspecified",
-                Dark = "Dark",
-                Light = "Light"
-            };
-            Assert.AreEqual("Unspecified", str.Value);
+
+            var app = new Application();
+            Assert.AreEqual(OSAppTheme.Unspecified, app.RequestedTheme);
         }
 
         [Test]
         public void RequestedThemeIsSet()
         {
             MockForms.Init(requestedTheme: OSAppTheme.Dark);
-            var str = new OnAppTheme<string>
-            {
-                Default = "Unspecified",
-                Dark = "Dark",
-                Light = "Light"
-            };
-            Assert.AreEqual("Dark", str.Value);
+            var app = new Application();
+            Assert.AreEqual(OSAppTheme.Dark, app.RequestedTheme);
         }
     }
 }

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.220655" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -4,6 +4,6 @@
 		<AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
+		<PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
 	</ItemGroup>
 </Project>

--- a/Xamarin.Forms.Mocks.nuspec
+++ b/Xamarin.Forms.Mocks.nuspec
@@ -15,7 +15,7 @@
       <releaseNotes>Upgraded to netstandard2.0</releaseNotes>
       <tags>Xamarin, Xamarin.Forms, Mocks, Unit Testing</tags>
       <dependencies>
-         <dependency id="Xamarin.Forms" version="3.5.0.129452" />
+         <dependency id="Xamarin.Forms" version="4.6.0.726" />
       </dependencies>
    </metadata>
 </package>

--- a/Xamarin.Forms.Mocks/MockForms.cs
+++ b/Xamarin.Forms.Mocks/MockForms.cs
@@ -14,9 +14,9 @@ namespace Xamarin.Forms.Mocks
         /// </summary>
         public static Action<Uri> OpenUriAction { get; set; }
 
-        public static void Init(string runtimePlatform = "Test", TargetIdiom idiom = default(TargetIdiom))
+        public static void Init(string runtimePlatform = "Test", TargetIdiom idiom = default(TargetIdiom), OSAppTheme requestedTheme = OSAppTheme.Unspecified)
         {
-            Device.PlatformServices = new PlatformServices(runtimePlatform);
+            Device.PlatformServices = new PlatformServices(runtimePlatform, requestedTheme);
             Device.Idiom = idiom;
             Device.Info = new MockDeviceInfo();
             DependencyService.Register<SystemResourcesProvider>();

--- a/Xamarin.Forms.Mocks/PlatformServices.cs
+++ b/Xamarin.Forms.Mocks/PlatformServices.cs
@@ -11,9 +11,10 @@ namespace Xamarin.Forms.Mocks
     {
         private readonly IsolatedStorageFile _isolatedStorageFile = new IsolatedStorageFile();
 
-        public PlatformServices(string runtimePlatform)
+        public PlatformServices(string runtimePlatform, OSAppTheme requestedTheme)
         {
             RuntimePlatform = runtimePlatform;
+            RequestedTheme = requestedTheme;
         }
 
         public bool IsInvokeRequired
@@ -26,6 +27,8 @@ namespace Xamarin.Forms.Mocks
             get;
             private set;
         }
+
+        public OSAppTheme RequestedTheme { get; }
 
         public void BeginInvokeOnMainThread(Action action)
         {
@@ -83,6 +86,12 @@ namespace Xamarin.Forms.Mocks
                 if (!callback())
                     return;
             }
+        }
+
+        public Color GetNamedColor(string name)
+        {
+            // Not supported on this platform
+            return Color.Default;
         }
     }
 }

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Xamarin.Forms.Core.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
+		<PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/issues/51

This updates Xamarin.Forms.Mocks to Xamarin.Forms 4.6

This contained 2 breaking API changes in IPlatformServices

- OSAppTheme: This has been added as an optional parameter that you can pass when calling MockForms.Init
- GetNamedColor: This simply returns Color.Default which is the same implementation used on several current Xamarin.Forms target platforms and internal test mocks.