### PR TITLE
Bump to Xamarin.Forms 4.7.0.968

### DIFF
--- a/TestAssembly/TestAssembly.csproj
+++ b/TestAssembly/TestAssembly.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.7.0.773-pre1" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
   </ItemGroup>
 
 </Project>

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.7.0.773-pre1" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -4,6 +4,6 @@
 		<AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.7.0.773-pre1" />
+		<PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
 	</ItemGroup>
 </Project>

--- a/Xamarin.Forms.Mocks.nuspec
+++ b/Xamarin.Forms.Mocks.nuspec
@@ -15,7 +15,7 @@
       <releaseNotes>Upgraded to netstandard2.0</releaseNotes>
       <tags>Xamarin, Xamarin.Forms, Mocks, Unit Testing</tags>
       <dependencies>
-         <dependency id="Xamarin.Forms" version="4.7.0.773-pre1" />
+         <dependency id="Xamarin.Forms" version="4.7.0.968" />
       </dependencies>
    </metadata>
 </package>

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Xamarin.Forms.Core.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.7.0.773-pre1" />
+		<PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />

--- a/build.cake
+++ b/build.cake
@@ -18,7 +18,7 @@ var dirs = new[]
 };
 string sln = "./Xamarin.Forms.Mocks.sln";
 string version = "4.7.0.1";
-string suffix = "-pre";
+string suffix = "";
 
 MSBuildSettings MSBuildSettings()
 {


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/issues/58

We can also drop the `-pre` suffix on this package.