### PR TITLE
Bump to Xamarin.Forms 4.8.0.1269

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Make sure to choose the appropriate version of this package for the version of X
 
 | Xamarin.Forms  | Xamarin.Forms.Mocks |
 | -------------- | ------------------- |
+| 4.8.0.x        | 4.8.0.x             |
 | 4.7.0.x        | 4.7.0.x             |
 | 4.6.0.x        | 4.6.0.x             |
 | 3.5.x-4.5.x    | 3.5.0.x             |

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ Make sure to choose the appropriate version of this package for the version of X
 
 | Xamarin.Forms  | Xamarin.Forms.Mocks |
 | -------------- | ------------------- |
-| 4.8.0.x        | 4.8.0.x             |
 | 4.7.0.x        | 4.7.0.x             |
 | 4.6.0.x        | 4.6.0.x             |
 | 3.5.x-4.5.x    | 3.5.0.x             |

--- a/TestAssembly/TestAssembly.csproj
+++ b/TestAssembly/TestAssembly.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
 
 </Project>

--- a/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
+++ b/Xamarin.Forms.Mocks.Tests/Xamarin.Forms.Mocks.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
+++ b/Xamarin.Forms.Mocks.Xaml/Xamarin.Forms.Mocks.Xaml.csproj
@@ -4,6 +4,6 @@
 		<AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
+		<PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
 	</ItemGroup>
 </Project>

--- a/Xamarin.Forms.Mocks.nuspec
+++ b/Xamarin.Forms.Mocks.nuspec
@@ -15,7 +15,7 @@
       <releaseNotes>Upgraded to netstandard2.0</releaseNotes>
       <tags>Xamarin, Xamarin.Forms, Mocks, Unit Testing</tags>
       <dependencies>
-         <dependency id="Xamarin.Forms" version="4.7.0.968" />
+         <dependency id="Xamarin.Forms" version="4.8.0.1269" />
       </dependencies>
    </metadata>
 </package>

--- a/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
+++ b/Xamarin.Forms.Mocks/Xamarin.Forms.Mocks.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Xamarin.Forms.Core.UnitTests</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="4.7.0.968" />
+		<PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Xamarin.Forms.Mocks.Xaml\Xamarin.Forms.Mocks.Xaml.csproj" />


### PR DESCRIPTION
Not sure if I should bump to the latest stable version. I targeted the first 4.8.x stable release so people using 4.8 everywhere could use it.
If you think I should target the latest release, please let me know :)